### PR TITLE
Fix windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,13 +51,9 @@ build_script:
   - cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=%CD%\..\install -DTERRA_SLIB_INCLUDE_LLVM=OFF -DTERRA_SLIB_INCLUDE_LUAJIT=OFF -DCMAKE_GENERATOR_PLATFORM=x64
   - cmake --build . --target INSTALL --config Release
+  # This is apparently different from cmake install. It is unclear if there is a better way
+  - cmake -P cmake_install.cmake
   - cd ..
-  # # There is probably a better way to do this...
-  # - if /I "%VS_MAJOR_VERSION%" EQU "14" (call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64)
-  # - if /I "%VS_MAJOR_VERSION%" EQU "12" (call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64)
-  # - cd msvc
-  # - nmake
-  # - cd ..
 
   # Package for release
   - set TERRA_SHARE_PATH=%TERRA_DIR%\release\share\terra

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
 build_script:
   - cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=%CD%\..\install -DTERRA_SLIB_INCLUDE_LLVM=OFF -DTERRA_SLIB_INCLUDE_LUAJIT=OFF -DCMAKE_GENERATOR_PLATFORM=x64
-  - cmake --build . --target INSTALL
+  - cmake --build . --target INSTALL --config Release
   - cd ..
   # # There is probably a better way to do this...
   # - if /I "%VS_MAJOR_VERSION%" EQU "14" (call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -244,6 +244,9 @@ target_link_libraries(TerraLibraryShared
     ${LUAJIT_LIBRARIES}
     ${ALL_LLVM_LIBRARIES}
     ${LLVM_SYSTEM_LIBRARIES}
+    shlwapi.lib
+    version.lib
+    Dbghelp.lib
 )
 
 if(APPLE)
@@ -334,6 +337,9 @@ else()
       ${LUAJIT_LIBRARIES}
       ${ALL_LLVM_LIBRARIES}
       ${LLVM_SYSTEM_LIBRARIES}
+      shlwapi.lib
+      version.lib
+      Dbghelp.lib
   )
 endif()
 

--- a/tests/option_e.t
+++ b/tests/option_e.t
@@ -4,9 +4,18 @@ local function getcommand()
     local prefix = terralib and terralib.terrahome and
                    terralib.terrahome .."/bin/terra" or "../terra"
     if ffi.os == "Windows" then
-        prefix = "cmd /c " .. prefix:gsub("[/\\]","\\\\")
+        prefix = prefix:gsub("[/\\]","\\\\")
     end
     return prefix
 end
 
-assert(os.execute(getcommand() .. " -e \"local c = terralib.includec([[stdio.h]]); terra f() c.printf([[hello]]) end; f(); print()\"") == 0)
+-- On windows, if the source exe has a space in it, we have to surround not only the paths with quotes, but also the entire command with quotes
+local cmd = " -e \"local c = terralib.includec([[stdio.h]]); terra f() c.printf([[hello]]) end; f(); print()\""
+if ffi.os == "Windows" then
+  cmd = [[cmd /c ""]] .. getcommand() .. "\"" .. cmd .. "\""
+else
+  cmd = getcommand() .. cmd
+end
+
+print(cmd)
+assert(os.execute(cmd) == 0)

--- a/tests/run
+++ b/tests/run
@@ -19,7 +19,7 @@ local function getcommand(file)
     local prefix = terralib and terralib.terrahome and 
                    terralib.terrahome .."/bin/terra" or "../terra"
     if ffi.os == "Windows" then
-        prefix = "cmd /c " .. prefix:gsub("[/\\]","\\\\")
+        prefix = "cmd /c \"" .. prefix:gsub("[/\\]","\\\\") .. "\""
     end
     return prefix
 end


### PR DESCRIPTION
This fixes the missing libraries that were causing errors, and also tells cmake to build Release instead of Debug (which was causing conflicts with the runtime). It also fixes several tests so they work with spaces. I do not know if this will work on appveyor.

These are the absolute minimum changes required to get terra building on windows via cmake. I would like to get terra working on LLVM 8 so it can be added to vcpkg, but that can come after this is merged.